### PR TITLE
feat(ui): Filter features by current project when creating tasks

### DIFF
--- a/internal/ui/input_handlers_task.go
+++ b/internal/ui/input_handlers_task.go
@@ -27,8 +27,9 @@ func (m *MainModel) handleTaskCreateKey(key string) (tea.Cmd, bool) {
 			defaultProjectID = *m.programContext.SelectedProjectID
 		}
 
-		// Get available features
-		availableFeatures := m.GetUniqueFeatures()
+		// Get available features filtered by current project
+		// Use GetFeaturesForProjectSelection() to respect project context
+		availableFeatures := m.GetFeaturesForProjectSelection()
 
 		// Get default feature from current context if any
 		defaultFeature := ""


### PR DESCRIPTION
When creating a new task (pressing 'c'), the feature dropdown now shows only features that exist in the current project, rather than features from all projects.

Changes:
- Use GetFeaturesForProjectSelection() instead of GetUniqueFeatures() in handleTaskCreateKey()
- GetFeaturesForProjectSelection() filters by current project context while respecting status filters and showing all available features (ignoring feature filters)

Benefits:
- Improved UX: Users see only relevant features for their context
- Consistency: Aligns with existing feature selection modal behavior
- Reduced clutter: No irrelevant features from other projects

This leverages the existing GetFeaturesForProjectSelection() method which was already designed for this exact use case (showing project-scoped features without feature filter restrictions).